### PR TITLE
Update gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,11 +254,9 @@ Try `./myapp -c --help` for a list of available options. They are also listed [h
 
 If you want to modify the Java code only, it's sufficient to invoke Maven.
 
-```
-mvn clean package
-```
+    $ ./gradlew clean assemble
 
-This will create a `packr-VERSION.jar` file in `target` which you can invoke as described in the Usage section above.
+This will create a `packr-VERSION.jar` file in `Packr/build/libs` diectory, you may invoke as described in the Usage section above.
 
 If you want to compile the native executables, please follow [these instructions](https://github.com/libgdx/packr/blob/master/src/main/native/README.md). Each of the build scripts will create executable files for the specific platform and copy them to src/main/resources.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,6 @@ plugins {
 }
 
 tasks.named<Wrapper>("wrapper") {
-   gradleVersion = "6.1.1"
+   gradleVersion = "6.3"
    distributionType = Wrapper.DistributionType.ALL
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -17,6 +17,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Moved to Gradle 6.3

I'm working on a Java 11 project and using the Java 11 JDK and JRE, once I moved to Gradle 6.3 the project compiled without issue. I believe this change will add support for Java 9 and higher.

Thank you!